### PR TITLE
[DIGISOS-676] Juridisk logg i Arbeids- og velferdsetaten : Filer og c…

### DIFF
--- a/json/vedlegg/vedleggSpesifikasjon.json
+++ b/json/vedlegg/vedleggSpesifikasjon.json
@@ -46,6 +46,9 @@
       "properties": {
         "filnavn": {
           "type": "string"
+        },
+        "sha512": {
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
Filformat vedlegg må ha en checksum. Siden det er flere filer som er mulig å legge til ved et vedlegg, så må det være en checksum for hver fil som vedlegges i vedlegget.