### PR TITLE
Retter adressesubklasseproblem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
                     <classNamePrefix>Json</classNamePrefix>
                     <generateBuilders>true</generateBuilders>
                     <useCommonsLang3>true</useCommonsLang3>
+                    <includeAdditionalProperties>false</includeAdditionalProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/no/nav/sbl/soknadsosialhjelp/json/AdresseMixIn.java
+++ b/src/main/java/no/nav/sbl/soknadsosialhjelp/json/AdresseMixIn.java
@@ -1,0 +1,19 @@
+package no.nav.sbl.soknadsosialhjelp.json;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import no.nav.sbl.soknadsosialhjelp.soknad.adresse.JsonGateAdresse;
+import no.nav.sbl.soknadsosialhjelp.soknad.adresse.JsonMatrikkelAdresse;
+import no.nav.sbl.soknadsosialhjelp.soknad.adresse.JsonPostboksAdresse;
+import no.nav.sbl.soknadsosialhjelp.soknad.adresse.JsonUstrukturertAdresse;
+
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = JsonPostboksAdresse.class, name = "postboks"),
+    @JsonSubTypes.Type(value = JsonGateAdresse.class, name = "gateadresse"),
+    @JsonSubTypes.Type(value = JsonMatrikkelAdresse.class, name = "matrikkeladresse"),
+    @JsonSubTypes.Type(value = JsonUstrukturertAdresse.class, name = "ustrukturert"),
+})
+public interface AdresseMixIn {}

--- a/src/test/java/AdresseSubTypeTest.java
+++ b/src/test/java/AdresseSubTypeTest.java
@@ -1,0 +1,30 @@
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import no.nav.sbl.soknadsosialhjelp.json.AdresseMixIn;
+import no.nav.sbl.soknadsosialhjelp.soknad.adresse.JsonAdresse;
+import no.nav.sbl.soknadsosialhjelp.soknad.adresse.JsonGateAdresse;
+import no.nav.sbl.soknadsosialhjelp.soknad.common.JsonKilde;
+
+public class AdresseSubTypeTest {
+
+    @Test
+    public void subtypeSkalBenyttesVedLesing() throws Exception {
+        final File testfile = new File("src/test/resources/json/soknad/parts/adresse/fullstendig-gateadresse.json");
+        
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.addMixIn(JsonAdresse.class, AdresseMixIn.class);
+        
+        final JsonAdresse jsonAdresse = mapper.readValue(testfile, JsonAdresse.class);
+        assertEquals("Riktig subklasse skal velges", JsonGateAdresse.class, jsonAdresse.getClass());
+        assertEquals("Skal lese felt som kun finnes på superklasse", JsonKilde.BRUKER, jsonAdresse.getKilde());
+        
+        final JsonGateAdresse gateadresse = (JsonGateAdresse) jsonAdresse; 
+        assertEquals("Skal lese felt som kun finnes på subklasse", "Testeveien", gateadresse.getGatenavn());
+    }
+}


### PR DESCRIPTION
Retter problem med bruk av subklasser ved import av JSON-data ved bruk av autogenerert Javakode.

Merk at "additionalProperties" har blitt fjernet fra alle objekter. Dette for å fremprovosere andre liknende latente feil.Hvis FSL/Fiks vil benytte autogenerert kode må "additionalProperties" aktiveres igjen -- ellers blir det ikke mulig å legge til nye felt på en kompatibel måte.

Ved bruk av autogenererte klasser til lesing av JSON må Mixin legges til. Eksempel:
```
final ObjectMapper mapper = new ObjectMapper();
mapper.addMixIn(JsonAdresse.class, AdresseMixIn.class);
```