### PR TITLE
Utvider vedlegg.json med referanse til hendelse, og legger til referanse på dokumenter

### DIFF
--- a/json/digisos/soker/parts/hendelse/dokumentasjonEtterspurt.json
+++ b/json/digisos/soker/parts/hendelse/dokumentasjonEtterspurt.json
@@ -50,6 +50,11 @@
           },
           "innsendelsesfrist": {
             "$ref": "../../../../types/tidspunkt.json"
+          },
+          "dokumentreferanse": {
+            "title": "Dokumentreferanse",
+            "type": "string",
+            "description": "Referansen til dette dokumentet som etterspørres. Vil bli sendt tilbake i vedlegg.json"
           }
         },
         "required": [

--- a/json/digisos/soker/parts/hendelse/dokumentasjonkrav.json
+++ b/json/digisos/soker/parts/hendelse/dokumentasjonkrav.json
@@ -48,7 +48,7 @@
 		},
 		"status": {
 			"type": "string",
-			"description": "Status som forteller om dokumentasjonkravet er relevant eller ikke. \nRELEVANT brukes for alle dokumentasjonkrav som er relevante for saken. \nLEVERT_TIDLIGERE benyttes dersom dokumentasjonkravet er levert via andre kanaler, eller er oppfylt av et annet dokument søker har sendt inn. \nANNULLERT benyttes dersom et dokumentasjonkrav er feilregistrert, skal fjernes av tekniske årsaker eller er erstattet av nytt vedtak. Annullerte dokumentasjonkrav vil ikke vises, og benyttes i tilfeller der et dokumentasjonkrav skal slettes fra nav.no på grunn av en feilsituasjon. \nOPPFYLT og IKKE_OPPFYLT er deprecated men fjernes ikke, for bakover-kompatibilitet. De blir tolket som RELEVANT.",
+			"description": "Status som forteller om dokumentasjonkravet er relevant eller ikke. \n* RELEVANT - benyttes for alle dokumentasjonkrav som er relevante for saken. \n* LEVERT_TIDLIGERE - benyttes dersom dokumentasjonkravet er levert via andre kanaler, eller er oppfylt av et annet dokument søker har sendt inn. \n* ANNULLERT - benyttes dersom et dokumentasjonkrav er feilregistrert, skal fjernes av tekniske årsaker eller er erstattet av nytt vedtak. Annullerte dokumentasjonkrav vil ikke vises, og benyttes i tilfeller der et dokumentasjonkrav skal slettes fra nav.no på grunn av en feilsituasjon. \n* OPPFYLT og IKKE_OPPFYLT - er deprecated men fjernes ikke, for bakover-kompatibilitet. De blir tolket som RELEVANT.",
 			"enum": [
 				"RELEVANT",
 				"LEVERT_TIDLIGERE",

--- a/json/digisos/soker/parts/hendelse/vilkar.json
+++ b/json/digisos/soker/parts/hendelse/vilkar.json
@@ -45,7 +45,7 @@
 		},
 		"status": {
 			"type": "string",
-			"description": "Status som forteller om vilkåret er relevant eller ikke. \nRELEVANT brukes for alle vilkåret som er relevante for saken. \nANNULLERT benyttes dersom et vilkår er feilregistrert, skal fjernes av tekniske årsaker eller er erstattet av nytt vedtak. Annullerte vilkår vil ikke vises, og benyttes i tilfeller der et vilkår skal slettes fra nav.no på grunn av en feilsituasjon. \nOPPFYLT og IKKE_OPPFYLT er deprecated men fjernes ikke, for bakover-kompatibilitet. De blir tolket som RELEVANT.",
+			"description": "Status som forteller om vilkåret er relevant eller ikke. \n* RELEVANT - benyttes for alle vilkår som er relevante for saken. \n* ANNULLERT - benyttes dersom et vilkår er feilregistrert, skal fjernes av tekniske årsaker eller er erstattet av nytt vedtak. Annullerte vilkår vil ikke vises, og benyttes i tilfeller der et vilkår skal slettes fra nav.no på grunn av en feilsituasjon. \n* OPPFYLT og IKKE_OPPFYLT  - er deprecated men fjernes ikke, for bakover-kompatibilitet. De blir tolket som RELEVANT.",
 			"enum": [
 				"RELEVANT",
 				"ANNULLERT",

--- a/json/swagger.json
+++ b/json/swagger.json
@@ -68,8 +68,8 @@
 			    "tags": [
 					"vedlegg"
 				],
-				"summary": "Versjon 1.0.0",
-				"description": "Denne dokumentasjonen er generert ut fra et [json-schema](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/json/vedlegg/vedleggSpesifikasjon.json). Skjemaet kan utvides slik at det er egnet til autogenerering av kode, men dette må i så fall diskuteres på Slack først.",
+				"summary": "Versjon 1.1.0",
+				"description": "Denne dokumentasjonen er generert ut fra et [json-schema](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/json/vedlegg/vedleggSpesifikasjon.json). Skjemaet kan utvides slik at det er egnet til autogenerering av kode, men dette må i så fall diskuteres på Slack først.\n## Endringer\n### Versjon 1.1.0\n* Utvidelse med to nye, optional felter: hendelseType og hendelseReferanse. Som følge av løsningsbeskrivelsen 'Nye felter i vedlegg.json' \n### Versjon 1.0.0\n* Lanseringsversjon \n",
 				"responses": {
 					"filformat": {
 						"schema": {
@@ -84,8 +84,8 @@
 			    "tags": [
 					"data fra fagsystem"
 				],
-				"summary": "Versjon 1.2.0",
-				"description": "Definisjon av fil som brukes til å sende data, som søker skal kunne se, fra fagsystemet. Denne dokumentasjonen er generert ut fra et [json-schema](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/json/digisos/soker/digisos-soker.json).\n\n## Krav\n* Allerede fra første innsending av \"digisos-soker.json\" _må_ \"hendelser\" inneholde hendelsen \"soknadsStatus\" med statuskode \"MOTTATT\".\n\n## Eksempler og testfiler\n* Eksempler på søkerinnsyn-JSON med [kun påkrevde data](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/src/test/resources/json/digisos/soker/minimal.json) og [komplett utfylt](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/src/test/resources/json/digisos/soker/komplett.json).\n* [Flere testfiler](https://github.com/navikt/soknadsosialhjelp-filformat/tree/master/src/test/resources/json/digisos/soker)\n\n## Endringer\n### Versjon 1.2.0\n* Utvidet hendelsene vilkar og dokumentasjonkrav med bakoverkompatible endringer fra løsningsbeskrivelsen om vilkår og dokumentasjonskrav. \n",
+				"summary": "Versjon 1.2.1",
+				"description": "Definisjon av fil som brukes til å sende data, som søker skal kunne se, fra fagsystemet. Denne dokumentasjonen er generert ut fra et [json-schema](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/json/digisos/soker/digisos-soker.json).\n\n## Krav\n* Allerede fra første innsending av \"digisos-soker.json\" _må_ \"hendelser\" inneholde hendelsen \"soknadsStatus\" med statuskode \"MOTTATT\".\n\n## Eksempler og testfiler\n* Eksempler på søkerinnsyn-JSON med [kun påkrevde data](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/src/test/resources/json/digisos/soker/minimal.json) og [komplett utfylt](https://raw.githubusercontent.com/navikt/soknadsosialhjelp-filformat/master/src/test/resources/json/digisos/soker/komplett.json).\n* [Flere testfiler](https://github.com/navikt/soknadsosialhjelp-filformat/tree/master/src/test/resources/json/digisos/soker)\n\n## Endringer\n### Versjon 1.2.1\n* Utvider dokumentasjonEtterspurt med dokumentreferanse på dokumenter. Som følge av løsningsbeskrivelsen 'Nye felter i vedlegg.json' \n### Versjon 1.2.0\n* Utvidet hendelsene vilkar og dokumentasjonkrav med bakoverkompatible endringer fra løsningsbeskrivelsen om vilkår og dokumentasjonskrav. \n",
 				"responses": {
 					"filformat": {
 						"description": "Definisjon av søkers innsynsfil. Se på \"Model\" for definisjon av hvert enkelt felt. Se separate typedefinisjoner nederst på siden der det er forskjellige type-alternativer (nå gjelder dette kun for \"hendelse\" og \"filreferanse\", men det kan bli flere typer senere).",

--- a/json/vedlegg/vedleggSpesifikasjon.json
+++ b/json/vedlegg/vedleggSpesifikasjon.json
@@ -43,6 +43,20 @@
           "items": {
             "$ref": "#/definitions/fil"
           }
+        },
+        "hendelseType": {
+          "description": "Angir typen til hendelsen som fikk brukeren til å laste opp dette vedlegget. Mulige typer:\n* dokumentasjonEtterspurt - om vedlegget ble lastet opp på grunn av hendelsen dokumentasjonEtterspurt \n* dokumentasjonkrav - om vedlegget ble lastet opp på grunn av hendelsen dokumentasjonkrav \n* soknad - om vedlegget ble lastet opp på grunn av vedleggskrav generert av søknaden \n* bruker - når bruker selv velger å laste opp annen dokumentasjon",
+          "type": "string",
+          "enum": [
+            "dokumentasjonEtterspurt",
+            "dokumentasjonkrav",
+            "soknad",
+            "bruker"
+          ]
+        },
+        "hendelseReferanse": {
+          "description": "Peker på referansen til hendelsen som fikk brukeren til å laste opp dette vedlegget.",
+          "type": "string"
         }
       }
     },

--- a/src/test/java/VedleggTest.java
+++ b/src/test/java/VedleggTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 public class VedleggTest {
@@ -35,7 +36,10 @@ public class VedleggTest {
                 testMed("gyldig_minimal2", true),
                 testMed("gyldig_standard", true),
                 testMed("gyldig_ekstrafelter", true),
+                testMed("gyldig_komplett", true),
+                testMed("gyldig_hendelseTyper", true),
                 testMed("ikkegyldig_ugyldigvedlegg", false),
+                testMed("ikkegyldig_ugyldigHendelseType", false),
                 testMed("ikkegyldig_ugyldigfil", false)
                 );
     }
@@ -55,7 +59,7 @@ public class VedleggTest {
         final String message = "Fil " + testfile.getName() + " forventes " + (forventGyldig ? "gyldig" : "ugyldig") + "\n" + report;
         assertEquals(message, forventGyldig, report.isSuccess());
         if (forventGyldig) {
-            assertEquals("Det er warnings for fil " + testfile.getName() + "\n" + report, true, !JsonSosialhjelpValidator.hasWarnings(report));
+            assertFalse("Det er warnings for fil " + testfile.getName() + "\n" + report, JsonSosialhjelpValidator.hasWarnings(report));
         }
     }
 }

--- a/src/test/resources/json/digisos/soker/komplett.json
+++ b/src/test/resources/json/digisos/soker/komplett.json
@@ -55,7 +55,8 @@
 				{
 					"dokumenttype": "Strømfaktura",
 					"tilleggsinformasjon": "For periode 01.01.2019 til 01.02.2019",
-					"innsendelsesfrist": "2018-10-20T07:37:00.134Z"
+					"innsendelsesfrist": "2018-10-20T07:37:00.134Z",
+					"dokumentreferanse": "dokumentreferanse1"
 				},
 				{
 					"dokumenttype": "Kopi av depositumskonto",

--- a/src/test/resources/json/digisos/soker/parts/hendelse/dokumentasjonEtterspurt/dokument-har-dokumentreferanse.json
+++ b/src/test/resources/json/digisos/soker/parts/hendelse/dokumentasjonEtterspurt/dokument-har-dokumentreferanse.json
@@ -1,0 +1,21 @@
+{
+  "type": "dokumentasjonEtterspurt",
+  "hendelsestidspunkt": "2018-10-11T13:42:00.134Z",
+  "forvaltningsbrev": {
+    "referanse": {
+      "type": "dokumentlager",
+      "id": "12345678-9abc-def0-1234-56789abcdef0"
+    }
+  },
+  "dokumenter": [
+    {
+      "dokumenttype": "Husleiekvittering Januar",
+      "innsendelsesfrist": "2018-10-20T07:37:00.134Z",
+      "dokumentreferanse": "dokumentreferanse1"
+    },
+    {
+      "dokumenttype": "Husleiekvittering Februar",
+      "innsendelsesfrist": "2018-10-20T07:37:00.134Z"
+    }
+  ]
+}

--- a/src/test/resources/json/digisos/soker/parts/hendelse/dokumentasjonEtterspurt/feil-dokument-har-feil-dokumentreferanse.json
+++ b/src/test/resources/json/digisos/soker/parts/hendelse/dokumentasjonEtterspurt/feil-dokument-har-feil-dokumentreferanse.json
@@ -1,0 +1,21 @@
+{
+  "type": "dokumentasjonEtterspurt",
+  "hendelsestidspunkt": "2018-10-11T13:42:00.134Z",
+  "forvaltningsbrev": {
+    "referanse": {
+      "type": "dokumentlager",
+      "id": "12345678-9abc-def0-1234-56789abcdef0"
+    }
+  },
+  "dokumenter": [
+    {
+      "dokumenttype": "Husleiekvittering Januar",
+      "innsendelsesfrist": "2018-10-20T07:37:00.134Z",
+      "dokumentreferanse": 34
+    },
+    {
+      "dokumenttype": "Husleiekvittering Februar",
+      "innsendelsesfrist": "2018-10-20T07:37:00.134Z"
+    }
+  ]
+}

--- a/src/test/resources/json/vedlegg/gyldig_hendelseTyper.json
+++ b/src/test/resources/json/vedlegg/gyldig_hendelseTyper.json
@@ -1,0 +1,22 @@
+{
+  "vedlegg": [
+    {
+      "hendelseType": "dokumentasjonEtterspurt"
+    },
+    {
+      "hendelseType": "dokumentasjonkrav"
+    },
+    {
+      "hendelseType": "soknad"
+    },
+    {
+      "hendelseType": "bruker"
+    },
+    {
+      "type": "faktura",
+      "tilleggsinfo": "sfo",
+      "status": "LastetOpp",
+      "filer": []
+    }
+  ]
+}

--- a/src/test/resources/json/vedlegg/gyldig_komplett.json
+++ b/src/test/resources/json/vedlegg/gyldig_komplett.json
@@ -1,0 +1,42 @@
+{
+  "vedlegg": [
+    {
+      "type": "faktura",
+      "tilleggsinfo": "sfo",
+      "status": "LastetOpp",
+      "hendelseType": "soknad",
+      "filer": [
+        {
+          "filnavn": "endaenfil-u95sdfght.png",
+          "sha512": "sha512sha512sha512sha512sha1"
+        },
+        {
+          "filnavn": "DCIM6666-ae94343bc.jpg",
+          "sha512": "sha512sha512sha512sha512sha2"
+        }
+      ]
+    },
+    {
+      "type": "faktura",
+      "tilleggsinfo": "tannregulering",
+      "status": "LastetOpp",
+      "hendelseType": "dokumentasjonEtterspurt",
+      "hendelseReferanse": "dokumentreferanse1",
+      "filer": [
+        {
+          "filnavn": "yeyeye-u95sdfght.png",
+          "sha512": "sha512sha512sha512sha512sha3"
+        },
+        {
+          "filnavn": "alalla-ae94343bc.jpg"
+        }
+      ]
+    },
+    {
+      "type": "faktura",
+      "tilleggsinfo": "oppvarming",
+      "status": "VedleggAlleredeSendt",
+      "filer": []
+    }
+  ]
+}

--- a/src/test/resources/json/vedlegg/ikkegyldig_ugyldigHendelseType.json
+++ b/src/test/resources/json/vedlegg/ikkegyldig_ugyldigHendelseType.json
@@ -1,0 +1,11 @@
+{
+  "vedlegg": [
+    {
+      "type": "faktura",
+      "tilleggsinfo": "sfo",
+      "status": "LastetOpp",
+      "hendelseType": "annet",
+      "filer": []
+    }
+  ]
+}


### PR DESCRIPTION
Utvider vedlegg.json med referanse til hendelse, og legger til referanse på dokumenter.

 * Utvider vedlegg.json med to nye felter: hendelseType og hendelseReferanse
 * Utvider dokumentasjonEtterspurt med et felt dokumenter.dokumentreferanse
 * Endrer litt på dformattering i description til vilkar og dokumentasjonkrav
 * Oppdaterer versjoner
 * Legger til nye testfiler og tester
 * Forenkler assertion i VedleggTest

 Ref: Løsningsbeskrivelse "Nye felter i vedlegg.json"
 https://navno.sharepoint.com/:w:/s/TeamDigisos86/EfGLMZ09owNBgX2afGo9wRgBRhJHU4YtLjUERnamfW_YYQ?e=ke43UP